### PR TITLE
#86: Update defaultTemplate.njk to insert URL-decoded text

### DIFF
--- a/src/assets/defaultTemplate.njk
+++ b/src/assets/defaultTemplate.njk
@@ -4,9 +4,9 @@
 {% if tags|length %}Topics:: #{{ tags | join(", #") }}{% endif %}
 
 ---
-# {{title}}
+# {{title | safe}}
 
-{% if excerpt %}{{excerpt}}{% endif %}
+{% if excerpt %}{{excerpt | safe}}{% endif %}
 
 ## Highlights
 {% endif -%}{% for highlight in highlights %}
@@ -21,7 +21,7 @@
 {%- endif -%}
 > [!{{callout}}]+ Updated on {{highlight.lastUpdate}}
 >
-> {{highlight.text.split("\n") | join("\n>")}}
+> {{highlight.text.split("\n") | join("\n>") | safe}}
 {% if highlight.note -%}> > {{highlight.note + "\n"}}{%- endif %}
 
 {%- endfor -%}


### PR DESCRIPTION
Pipe all text strings through nunjucks "safe" function to render URL-encoded text as raw.
Tested in Obsidian